### PR TITLE
Make it work with newer ASDFs

### DIFF
--- a/cxml-rng.asd
+++ b/cxml-rng.asd
@@ -1,28 +1,14 @@
-(defpackage :cxml-rng-system
-  (:use :asdf :cl))
-(in-package :cxml-rng-system)
-
-(defclass closure-source-file (cl-source-file) ())
-
-#+sbcl
-(defmethod perform :around ((o compile-op) (s closure-source-file))
-  ;; shut up already.  Correctness first.
-  (handler-bind ((sb-ext:compiler-note #'muffle-warning))
-    (let ((*compile-print* nil))
-      (call-next-method))))
-
-(defsystem :cxml-rng
-    :default-component-class closure-source-file
-    :serial t
-    :components
-    ((:file "package")
-     (:file "floats")
-     (:file "unicode")
-     (:file "nppcre")
-     (:file "types")
-     (:file "parse")
-     (:file "validate")
-     (:file "test")
-     (:file "clex")
-     (:file "compact"))
-    :depends-on (:cxml :cl-ppcre :yacc :parse-number :cl-base64))
+(defsystem "cxml-rng"
+  :serial t
+  :components
+  ((:file "package")
+   (:file "floats")
+   (:file "unicode")
+   (:file "nppcre")
+   (:file "types")
+   (:file "parse")
+   (:file "validate")
+   (:file "test")
+   (:file "clex")
+   (:file "compact"))
+  :depends-on ("cxml" "cl-ppcre" "yacc" "parse-number" "cl-base64"))

--- a/test.lisp
+++ b/test.lisp
@@ -241,10 +241,10 @@
      (assert *test-xmllint*)
      (let ((asdf::*VERBOSE-OUT* (make-string-output-stream)))
        (cond
-	 ((zerop (asdf:run-shell-command
-		  "xmllint -relaxng ~A ~A"
-		  schema
-		  (namestring (merge-pathnames href base))))
+	 ((zerop (nth-value 2
+                            (uiop:run-program
+                             `("xmllint" "-relaxng" ,schema ,(namestring (uiop:subpathname base href)))
+                             :ignore-error-status t)))
 	  (format t "PASS INSTANCE ~A~%" href)
 	  t)
 	 (t


### PR DESCRIPTION
asdf:run-shell-command is deprecated and using it will cause a style-warning, in the future a warning and/or an error. Fix that. While we're at it, make the .asd conform to the guidelines in https://gitlab.common-lisp.net/asdf/asdf/blob/master/doc/best_practices.md